### PR TITLE
[44] create CRUD for GenericTemplate

### DIFF
--- a/src/config/generateMigrations.js
+++ b/src/config/generateMigrations.js
@@ -18,6 +18,7 @@ function generateMigrations() {
     MenuHeader: models.MenuHeader,
     MenuDetail: models.MenuDetail,
     Media: models.Media,
+    GenericTemplate: models.GenericTemplate,
   };
 
   console.log('%csrc/config/generateMigrations.js:22 Models Sort', 'color: #007acc;', modelsSorted);

--- a/src/controllers/generic_template.controller.js
+++ b/src/controllers/generic_template.controller.js
@@ -1,0 +1,43 @@
+const httpStatus = require('http-status');
+const ApiError = require('../utils/ApiError');
+const catchAsync = require('../utils/catchAsync');
+const { genericTemplateService } = require('../services');
+
+const createGenericTemplate = catchAsync(async (req, res) => {
+  const genericTemplate = await genericTemplateService.createGenericTemplate(req.body);
+  res.status(httpStatus.CREATED).send(genericTemplate);
+});
+
+const getGenericTemplate = catchAsync(async (req, res) => {
+  const genericTemplate = await genericTemplateService.getGenericTemplateById(req.params.genericTemplateId);
+  if (!genericTemplate) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'Web page not found, please check the Id.');
+  }
+  res.send(genericTemplate);
+});
+
+const getGenericTemplatesByUserId = catchAsync(async (req, res) => {
+  const genericTemplate = await genericTemplateService.getGenericTemplatesByUserId(req.params.userId);
+  if (!genericTemplate) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'Web page not found, please check the User Id.');
+  }
+  res.send(genericTemplate);
+});
+
+const updateGenericTemplate = catchAsync(async (req, res) => {
+  const genericTemplate = await genericTemplateService.updateGenericTemplateById(req.params.genericTemplateId, req.body);
+  res.send(genericTemplate);
+});
+
+const deleteGenericTemplate = catchAsync(async (req, res) => {
+  await genericTemplateService.deleteGenericTemplateById(req.params.genericTemplateId);
+  res.status(httpStatus.NO_CONTENT).send();
+});
+
+module.exports = {
+  createGenericTemplate,
+  getGenericTemplatesByUserId,
+  getGenericTemplate,
+  updateGenericTemplate,
+  deleteGenericTemplate,
+};

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -9,3 +9,4 @@ module.exports.menuController = require('./menu.controller');
 module.exports.publishHistoryController = require('./publish_history.controller');
 module.exports.publicWebsiteController = require('./public_website.controller');
 module.exports.mediaController = require('./media.controller');
+module.exports.genericTemplateController = require('./generic_template.controller');

--- a/src/models/generic_template.model.js
+++ b/src/models/generic_template.model.js
@@ -1,0 +1,31 @@
+// GenericTemplate.js
+
+const { DataTypes } = require('sequelize');
+const { sequelize } = require('../config/sequelize');
+
+const GenericTemplate = sequelize.define(
+  'GenericTemplate',
+  {
+    sections: {
+      type: DataTypes.ARRAY(DataTypes.JSON),
+      allowNull: false,
+      defaultValue: [],
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'User',
+        key: 'id',
+      },
+    },
+  },
+  {
+    timestamps: true,
+    sequelize, // We need to pass the `sequelize` instance
+    modelName: 'GenericTemplate',
+    tableName: 'GenericTemplate',
+  }
+);
+
+module.exports = GenericTemplate;

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -11,6 +11,7 @@ const PublicWebsiteModel = require('./public_website.model');
 const { MenuHeader, associateMenuHeader } = require('./menu_header.model');
 const { MenuDetail, associateMenuDetail } = require('./menu_detail.model');
 const MediaModel = require('./media.model');
+const GenericTemplateModel = require('./generic_template.model');
 
 const models = {
   User: UserModel,
@@ -26,6 +27,7 @@ const models = {
   MenuDetail,
   PublicWebsite: PublicWebsiteModel,
   Media: MediaModel,
+  GenericTemplate: GenericTemplateModel,
 };
 
 associateMenuHeader(models);

--- a/src/routes/v1/generic_template.route.js
+++ b/src/routes/v1/generic_template.route.js
@@ -1,0 +1,251 @@
+const express = require('express');
+const auth = require('../../middlewares/auth');
+const validate = require('../../middlewares/validate');
+const genericTemplateValidation = require('../../validations/generic_template.validation');
+const genericTemplateController = require('../../controllers/generic_template.controller');
+
+const router = express.Router();
+
+router
+  .route('/')
+  .post(auth(), validate(genericTemplateValidation.createGenericTemplate), genericTemplateController.createGenericTemplate);
+
+router
+  .route('/user/:userId')
+  .get(
+    auth(),
+    validate(genericTemplateValidation.getGenericTemplatesByUserId),
+    genericTemplateController.getGenericTemplatesByUserId
+  );
+
+router
+  .route('/:genericTemplateId')
+  .get(auth(), validate(genericTemplateValidation.getGenericTemplate), genericTemplateController.getGenericTemplate)
+  .patch(auth(), validate(genericTemplateValidation.updateGenericTemplate), genericTemplateController.updateGenericTemplate)
+  .delete(
+    auth(),
+    validate(genericTemplateValidation.deleteGenericTemplate),
+    genericTemplateController.deleteGenericTemplate
+  );
+
+module.exports = router;
+
+/**
+ * @swagger
+ * tags:
+ *   name: Generic Templates
+ *   description: GenericTemplate management and retrieval
+ */
+
+/**
+ * @swagger
+ * /generic_templates:
+ *   post:
+ *     summary: Create a generic template
+ *     description: Any registered user can create other Generic Templates.
+ *     tags: [Generic Templates]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - NA
+ *             properties:
+ *               name:
+ *                 type: string
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 description: must be unique
+ *               password:
+ *                 type: string
+ *                 format: password
+ *                 minLength: 8
+ *                 description: At least one number and one letter
+ *             example:
+ *               name: fake name
+ *               email: fake@example.com
+ *               password: password1
+ *     responses:
+ *       "201":
+ *         description: Created
+ *         content:
+ *           application/json:
+ *             schema:
+ *                $ref: '#/components/schemas/User'
+ *       "400":
+ *         $ref: '#/components/responses/DuplicateEmail'
+ *       "401":
+ *         $ref: '#/components/responses/Unauthorized'
+ *       "403":
+ *         $ref: '#/components/responses/Forbidden'
+ *
+ *   get:
+ *     summary: Get all Generic Templates
+ *     description: Only admins can retrieve all Generic Templates.
+ *     tags: [Generic Templates]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: name
+ *         schema:
+ *           type: string
+ *         description: User name
+ *       - in: query
+ *         name: sortBy
+ *         schema:
+ *           type: string
+ *         description: sort by query in the form of field:desc/asc (ex. name:asc)
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         default: 10
+ *         description: Maximum number of Generic Templates
+ *       - in: query
+ *         name: generic
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: Page number
+ *     responses:
+ *       "200":
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 results:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/User'
+ *                 generic:
+ *                   type: integer
+ *                   example: 1
+ *                 limit:
+ *                   type: integer
+ *                   example: 10
+ *                 totalPages:
+ *                   type: integer
+ *                   example: 1
+ *                 totalResults:
+ *                   type: integer
+ *                   example: 1
+ *       "401":
+ *         $ref: '#/components/responses/Unauthorized'
+ *       "403":
+ *         $ref: '#/components/responses/Forbidden'
+ */
+
+/**
+ * @swagger
+ * /generic_templates/{id}:
+ *   get:
+ *     summary: Get a generic template
+ *     description: Logged in Generic Templates can fetch only their own generic template information. Only admins can fetch other Generic Templates.
+ *     tags: [Generic Templates]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: User id
+ *     responses:
+ *       "200":
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *                $ref: '#/components/schemas/User'
+ *       "401":
+ *         $ref: '#/components/responses/Unauthorized'
+ *       "403":
+ *         $ref: '#/components/responses/Forbidden'
+ *       "404":
+ *         $ref: '#/components/responses/NotFound'
+ *
+ *   patch:
+ *     summary: Update a generic template
+ *     description: Logged in Generic Templates can only update their own information. Only admins can update other Generic Templates.
+ *     tags: [Generic Templates]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: User id
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 description: must be unique
+ *               password:
+ *                 type: string
+ *                 format: password
+ *                 minLength: 8
+ *                 description: At least one number and one letter
+ *             example:
+ *               name: fake name
+ *               email: fake@example.com
+ *               password: password1
+ *     responses:
+ *       "200":
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *                $ref: '#/components/schemas/User'
+ *       "400":
+ *         $ref: '#/components/responses/DuplicateEmail'
+ *       "401":
+ *         $ref: '#/components/responses/Unauthorized'
+ *       "403":
+ *         $ref: '#/components/responses/Forbidden'
+ *       "404":
+ *         $ref: '#/components/responses/NotFound'
+ *
+ *   delete:
+ *     summary: Delete a generic template
+ *     description: Logged in Generic Templates can delete only themselves. Only admins can delete other Generic Templates.
+ *     tags: [Generic Templates]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: User id
+ *     responses:
+ *       "200":
+ *         description: No content
+ *       "401":
+ *         $ref: '#/components/responses/Unauthorized'
+ *       "403":
+ *         $ref: '#/components/responses/Forbidden'
+ *       "404":
+ *         $ref: '#/components/responses/NotFound'
+ */

--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -12,6 +12,7 @@ const publishHistoryRoute = require('./publish_history.route');
 const publicWebsiteRoute = require('./public_website.route');
 const docsRoute = require('./docs.route');
 const mediaRoute = require('./media.route');
+const genericTemplateRoute = require('./generic_template.route');
 const config = require('../../config/config');
 
 const router = express.Router();
@@ -64,6 +65,10 @@ const defaultRoutes = [
   {
     path: '/media',
     route: mediaRoute,
+  },
+  {
+    path: '/generic_templates',
+    route: genericTemplateRoute,
   },
 ];
 

--- a/src/services/generic_template.service.js
+++ b/src/services/generic_template.service.js
@@ -1,0 +1,73 @@
+const httpStatus = require('http-status');
+const { GenericTemplate } = require('../models');
+const ApiError = require('../utils/ApiError');
+
+/**
+ * Create a Generic Template
+ * @param {Object} genericTemplateBody
+ * @returns {Promise<GenericTemplate>}
+ */
+const createGenericTemplate = async (genericTemplateBody) => {
+  return GenericTemplate.create(genericTemplateBody);
+};
+
+/**
+ * Get Generic Template by id
+ * @param {ObjectId} id
+ * @returns {Promise<GenericTemplate>}
+ */
+const getGenericTemplateById = async (id) => {
+  return GenericTemplate.findByPk(id);
+};
+
+/**
+ * Query for Generic Template
+ * @param {userId} userId
+ * @returns {Promise<GenericTemplate>}
+ */
+const getGenericTemplatesByUserId = async (userId) => {
+  return GenericTemplate.findAll({
+    where: {
+      userId,
+    },
+  });
+};
+
+/**
+ * Update Generic Template by id
+ * @param {ObjectId} genericTemplateId
+ * @param {Object} updateBody
+ * @returns {Promise<GenericTemplate>}
+ */
+const updateGenericTemplateById = async (genericTemplateId, updateBody) => {
+  const genericTemplate = await getGenericTemplateById(genericTemplateId);
+
+  if (!genericTemplate) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'Web page not found, please check the id.');
+  }
+  Object.assign(genericTemplate, updateBody);
+  await genericTemplate.save();
+  return genericTemplate;
+};
+
+/**
+ * Delete Generic Template by id
+ * @param {ObjectId} genericTemplateId
+ * @returns {Promise<GenericTemplate>}
+ */
+const deleteGenericTemplateById = async (genericTemplateId) => {
+  const genericTemplate = await getGenericTemplateById(genericTemplateId);
+  if (!genericTemplate) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'Web page not found, please check the id.');
+  }
+  await genericTemplate.destroy();
+  return genericTemplate;
+};
+
+module.exports = {
+  createGenericTemplate,
+  getGenericTemplateById,
+  getGenericTemplatesByUserId,
+  updateGenericTemplateById,
+  deleteGenericTemplateById,
+};

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -12,3 +12,4 @@ module.exports.menuService = require('./menu.service');
 module.exports.publishHistoryService = require('./publish_history.service');
 module.exports.publicWebsiteService = require('./public_website.service');
 module.exports.mediaService = require('./media.service');
+module.exports.genericTemplateService = require('./generic_template.service');

--- a/src/validations/generic_template.validation.js
+++ b/src/validations/generic_template.validation.js
@@ -1,0 +1,48 @@
+const Joi = require('joi');
+
+const createGenericTemplate = {
+  body: Joi.object().keys({
+    userId: Joi.number().required(),
+    sections: Joi.array().items(Joi.object()),
+  }),
+};
+
+const getGenericTemplate = {
+  params: Joi.object().keys({
+    genericTemplateId: Joi.number().required(),
+  }),
+};
+
+const getGenericTemplatesByUserId = {
+  params: Joi.object().keys({
+    userId: Joi.number(),
+  }),
+  body: Joi.object().keys({
+    userId: Joi.number(),
+  }),
+};
+
+const updateGenericTemplate = {
+  params: Joi.object().keys({
+    genericTemplateId: Joi.number().required(),
+  }),
+  body: Joi.object()
+    .keys({
+      sections: Joi.array().items(Joi.object()),
+    })
+    .min(1),
+};
+
+const deleteGenericTemplate = {
+  params: Joi.object().keys({
+    genericTemplateId: Joi.number().required(),
+  }),
+};
+
+module.exports = {
+  createGenericTemplate,
+  getGenericTemplate,
+  getGenericTemplatesByUserId,
+  updateGenericTemplate,
+  deleteGenericTemplate,
+};

--- a/src/validations/index.js
+++ b/src/validations/index.js
@@ -10,3 +10,4 @@ module.exports.menuValidation = require('./menu.validation');
 module.exports.publishHistoryValidation = require('./publish_history.validation');
 module.exports.publicWebsiteValidation = require('./public_website.validation');
 module.exports.mediaValidation = require('./media.validation');
+module.exports.genericTemplateValidation = require('./generic_template.validation');

--- a/src/validations/page_template.validation.js
+++ b/src/validations/page_template.validation.js
@@ -33,7 +33,7 @@ const updatePageTemplate = {
     .min(1),
 };
 
-const deledeletePageTemplate = {
+const deletePageTemplate = {
   params: Joi.object().keys({
     pageTemplateId: Joi.number().required(),
   }),
@@ -44,5 +44,5 @@ module.exports = {
   getPageTemplate,
   getPageTemplatesByUserId,
   updatePageTemplate,
-  deledeletePageTemplate,
+  deletePageTemplate,
 };


### PR DESCRIPTION
This will provide a way to create generic templates for user's pages.

POST
<img width="1216" alt="image" src="https://github.com/user-attachments/assets/8042c20b-15e7-47d1-8c70-6dcf7a060ae1">


GET 1
<img width="1235" alt="image" src="https://github.com/user-attachments/assets/5f55f546-afa4-4011-bde9-b595547c2cb8">


GET 2
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/a368147d-818a-45af-a68a-4677c255ab27">


PATCH
<img width="1244" alt="image" src="https://github.com/user-attachments/assets/d9bef394-54b3-41e4-955c-158ab7ac0bc3">


DELETE
<img width="1216" alt="image" src="https://github.com/user-attachments/assets/29a6e043-9088-4d46-9f17-6ca7261fee8d">
